### PR TITLE
Enrich the "Text" field

### DIFF
--- a/lib/watson-discovery-setup.js
+++ b/lib/watson-discovery-setup.js
@@ -118,6 +118,7 @@ WatsonDiscoverySetup.prototype.createDiscoveryConfig = function(params) {
 
     // additional options for entity 'mentions', which will result in
     // more keywords that we can highlight in the UI
+    params.file.enrichments[0].source_field = 'Text';  // default is 'text'
     params.file.enrichments[0].options.features.entities.mentions = true;
     params.file.enrichments[0].options.features.entities.mention_types = true;
     params.file.enrichments[0].options.features.entities.sentence_locations = true;
@@ -301,7 +302,7 @@ WatsonDiscoverySetup.prototype.createDiscoveryCollection = function(params) {
     console.log('Creating discovery collection...');
     const createCollectionParams = {
       name: params.collection_name,
-      description: 'Discovery collection created by watson-discovery-ui.',
+      description: 'Discovery collection created by watson-discovery-food-reviews.',
       language_code: 'en_us'
     };
     Object.assign(createCollectionParams, params);


### PR DESCRIPTION
The food reviews have a "Text" field instead of the default "text".
Case matters.