### PR TITLE
Fix the date so timeslice will work. Use Score.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ const ITEMS_PER_PAGE = 7;
 const QUERY_NATURAL_LANGUAGE = 0;
 const QUERY_DISCO_LANGUAGE = 1;
 
-// the index of the fillter item in the aggrgation data returned 
+// the index of the filter item in the aggregation data returned
 // from the discovery query
 const ENTITY_DATA_INDEX      = 0;
 const CATEGORY_DATA_INDEX    = 1;
@@ -88,7 +88,7 @@ sortKeys.forEach(function(item) {
 });  
 
 /**
- * objectWithoutProperties - clear out unneded properties from object.
+ * objectWithoutProperties - clear out unneeded properties from object.
  * object: object to scan
  * properties: items in object to remove
  */
@@ -143,8 +143,8 @@ function formatData(data, passages, filterString) {
       id: dataItem.id,
       title: dataItem.Summary,
       text: dataItem.Text,
-      date: new Date(Number(dataItem.Time) * 1000).toISOString().substring(0, 10),
-      score: dataItem.result_metadata.score,
+      date: dataItem.date,
+      score: Number(dataItem.Score),  // Using the review Score because metadata result is always 1
       sentimentScore: sentimentScore,
       sentimentLabel: sentimentLabel,
       highlight: {

--- a/lib/watson-discovery-setup.js
+++ b/lib/watson-discovery-setup.js
@@ -366,6 +366,7 @@ WatsonDiscoverySetup.prototype.loadDiscoveryCollection = function(params) {
             const doc = docs[i];
             var file = fs.readFileSync(doc);
             var jsonFile = JSON.parse(file);
+            jsonFile['date'] = new Date(Number(jsonFile['Time']) * 1000).toISOString().substring(0, 10);
             const addDocParams = { file: jsonFile };
             Object.assign(addDocParams, params);
 


### PR DESCRIPTION
The timeslice query needs a number timestamp or a date string.
We have a timestamp string. Bummer. For now fix it when adding docs.
TODO: this means adding JSON in the Disco UI won't work.

The Score shown in the UI is always 1.0000. This is boring so use
the score from the review data for now.