### PR TITLE
automate disco config setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,10 @@ When the reader has completed this Code Pattern, they will understand how to:
 5. [Import Corpus Documents](#5-import-corpus-documents)
 6. [Create the model](#6-create-the-model)
 7. [Deploy the machine learning model to Watson Discovery](#7-deploy-the-machine-learning-model-to-watson-discovery)
-8. [Create Discovery Collection and Configuration](#8-create-discovery-collection-and-configuration)
-9. [Load the Discovery files](#9-load-the-discovery-files)
-10. [Configure credentials](#10-configure-credentials)
-11. [Run the application](#11-run-the-application)
-12. [Deploy and run the application on IBM Cloud](#12-deploy-and-run-the-application-on-ibm-cloud)
+8. [Create Discovery Collection](#8-create-discovery-collection)
+9. [Configure credentials](#90-configure-credentials)
+10. [Run the application](#10-run-the-application)
+11. [Deploy and run the application on IBM Cloud](#11-deploy-and-run-the-application-on-ibm-cloud)
 
 ## 1. Clone the repo
 ```
@@ -151,48 +150,22 @@ Then enter your IBM Cloud account information to locate your **Discovery** servi
 
 ![](doc/source/images/deployment-location.png)
 
-Once deployed, a **Model ID** will be created. Keep note of this value as it will be required later in this Code Pattern.
+Once deployed, a **Model ID** will be created. Keep note of this value as it will be required later when configuring your credentials.
 
 ![](doc/source/images/deployment-model.png)
 
 > NOTE: You can also view this **Model ID** by clicking the WDS link under 'Status'  against the deployed version.
 
-## 8. Create Discovery Collection and Configuration
+## 8. Create Discovery Collection
 
 Launch the **Watson Discovery** tool. Create a **new data collection**
 and give the data collection a unique name.
 
 ![](doc/source/images/create-collection.png)
 
-From the new collection data panel, under `Configuration` click the `Switch` button to switch to a new configuration file. Click `Create a new configuration` option.
-
-![](doc/source/images/switch-configuration.png)
-
-Enter a unique name and press `Create`.
-
-From the **Configuration Panel**, press the `Add enrichments` option. Ensure that the following **extraction** options are added: **Keyword**, **Entity**, and **Relation**.
-
-Also, assign your **Model ID** to both the **Entity Extraction** and **Relation Extraction**.
-
-> Note: These **Model ID** assignments are required to ensure your review data is properly enriched.
-
-![](doc/source/images/setup-config.png)
-
-Close the **Add Ennrichments** panel by pressing `Done`.
-
-Save the configuration by pressing `Apply & Save`, and then `Close`.
-
-## 9. Load the Discovery files
-
-From the new collection data panel, under `Add data to this collection` use `Drag and drop your documents here or browse from computer` to seed the content with the 2000 json files extracted from `data/food_reviews/`.
-
-> Note: If you don't load files, they will be automatically added when you run `npm start`.
-
-![](doc/source/images/load-docs.png)
-
 > Save the **environment_id** and **collection_id** for your `.env` file in the next step. You can find this data by clicking on `Use this collection API` under the **Collection Info** header located at the top right portion of the panel.
 
-## 10. Configure credentials
+## 9. Configure credentials
 ```
 cp env.sample .env
 ```
@@ -209,19 +182,20 @@ DISCOVERY_USERNAME=<add_discovery_username>
 DISCOVERY_PASSWORD=<add_discovery_password>
 DISCOVERY_ENVIRONMENT_ID=<add_discovery_environment>
 DISCOVERY_COLLECTION_ID=<add_discovery_collection>
+WKS_MODEL_ID=<add_wks_model_id>
 
 # Run locally on a non-default port (default is 3000)
 # PORT=3000
 ```
 
-## 11. Run the application
+## 10. Run the application
 
 1. Install [Node.js](https://nodejs.org/en/) runtime or NPM.
-1. Start the app by running `npm install`, followed by `npm start`.
+1. Start the app by running `npm install`, followed by `npm start`. If running for the first time, please be patient as the initialization process needs to load 2000 json files into your **Watson Discovery Collection** and may take several minutes.
 1. Access the UI by pointing your browser at `localhost:3000`.
 > Note: `PORT` can be configured in `.env`.
 
-## 12. Deploy and run the application on IBM Cloud
+## 11. Deploy and run the application on IBM Cloud
 
 To deploy to the IBM Cloud, make sure have the [IBM Cloud CLI](https://console.bluemix.net/docs/cli/reference/bluemix_cli/get_started.html#getting-started) tool installed. Then run the following commands to login using your IBM Cloud credentials.
 
@@ -259,6 +233,41 @@ To view logs, or get overview information about your app, use the IBM Cloud dash
 # Sample UI layout
 
 ![](doc/source/images/sample-output.png)
+
+# Discovery collection configuration details
+
+For reference, the following screen-shots detail how to set-up a collection configuration and load data files. In this Code Pattern, this process is completed for you when the applicatioon is initially started, but it is important to know what is happening in the background.
+
+If you were to create the configuration manually, these are the steps you would take:
+
+Launch the **Watson Discovery** tool. Create a **new data collection**
+and give the data collection a unique name.
+
+![](doc/source/images/create-collection.png)
+
+From the new collection data panel, under `Configuration` click the `Switch` button to switch to a new configuration file. Click `Create a new configuration` option.
+
+![](doc/source/images/switch-configuration.png)
+
+Enter the name `food-review-config` and press `Create`.
+
+From the **Configuration Panel**, press the `Add enrichments` option. Ensure that the following **extraction** options are added: **Keyword**, **Entity**, and **Relation**.
+
+Also, assign your **Model ID** to both the **Entity Extraction** and **Relation Extraction**.
+
+> Note: These **Model ID** assignments are required to ensure your review data is properly enriched.
+
+![](doc/source/images/setup-config.png)
+
+Close the **Add Ennrichments** panel by pressing `Done`.
+
+Save the configuration by pressing `Apply & Save`, and then `Close`.
+
+Once the configuration is created, you can proceed with loading discovery files.
+
+From the new collection data panel, under `Add data to this collection` use `Drag and drop your documents here or browse from computer` to seed the content with the 2000 json files extracted from `data/food_reviews/`.
+
+![](doc/source/images/load-docs.png)
 
 # Troubleshooting
 

--- a/env.sample
+++ b/env.sample
@@ -6,6 +6,7 @@ DISCOVERY_USERNAME=<add_discovery_username>
 DISCOVERY_PASSWORD=<add_discovery_password>
 DISCOVERY_ENVIRONMENT_ID=<add_discovery_environment_id>
 DISCOVERY_COLLECTION_ID=<add_discovery_collection_id>
+WKS_MODEL_ID=<add_wks_model_id>
 
 # Run locally on a non-default port (default is 3000)
 # PORT=3000

--- a/lib/watson-discovery-setup.js
+++ b/lib/watson-discovery-setup.js
@@ -53,13 +53,14 @@ WatsonDiscoverySetup.prototype.findDiscoveryConfig = function(params) {
             params.default_config_id = config.configuration_id;
           } else if (config.name === params.config_name) {
             // found the discovery config, so use it
-            console.log('Found discovery config with id: ' + config.configuration_id);
+            console.log('Found discovery config with name: ' + config.name);
             params.configuration_id = config.configuration_id;
             return resolve(params);
           }
         }
 
         // not found, so create it
+        console.log('No discovery config found, so it will be created');
         return resolve(params);
       }
     });
@@ -106,6 +107,7 @@ WatsonDiscoverySetup.prototype.createDiscoveryConfig = function(params) {
       return resolve(params);
     }
 
+    console.log('Creating collection config');
     params.name = params.config_name;
     params.file = {};
 
@@ -113,16 +115,24 @@ WatsonDiscoverySetup.prototype.createDiscoveryConfig = function(params) {
     params.file.normalizations = params.default_configuration.normalizations;
     params.file.enrichments = params.default_configuration.enrichments;
 
-    // add keyword extraction
+    // add keyword and relations extractions
     params.file.enrichments[0].options.features['keywords'] = {};
     params.file.enrichments[0].options.features['relations'] = {};
 
     // additional options for entity 'mentions', which will result in
     // more keywords that we can highlight in the UI
-    params.file.enrichments[0].source_field = 'Text';  // default is 'text'
+    params.file.enrichments[0].source_field = 'text';  // default is 'text'
     params.file.enrichments[0].options.features.entities.mentions = true;
     params.file.enrichments[0].options.features.entities.mention_types = true;
     params.file.enrichments[0].options.features.entities.sentence_locations = true;
+
+    // add WKS model ID
+    if (params.model_id) {
+      params.file.enrichments[0].options.features.entities.model = params.model_id;
+      params.file.enrichments[0].options.features.relations.model = params.model_id;
+    } else {
+      console.error('No WKS Model ID specified.');
+    }
 
     this.discoveryClient.createConfiguration(params, (err, data) => {
       if (err) {
@@ -133,7 +143,6 @@ WatsonDiscoverySetup.prototype.createDiscoveryConfig = function(params) {
         delete params['name'];
         delete params['file'];
         params.configuration_id = data.configuration_id;
-        console.log('Created configuration with id: ' + data.configuration_id);
         return resolve(params);
       }
     });
@@ -229,6 +238,7 @@ WatsonDiscoverySetup.prototype.findDiscoveryCollection = function(params) {
               console.log(collection);
               params.collection_name = collection.name;
               params.collection_id = collection.collection_id;
+              params.old_configuration_id = collection.configuration_id;
               return resolve(params);
             }
           } else if (collection.name === DISCOVERY_COLLECTION_NAME) {
@@ -236,15 +246,12 @@ WatsonDiscoverySetup.prototype.findDiscoveryCollection = function(params) {
             console.log(collection);
             params.collection_name = collection.name;
             params.collection_id = collection.collection_id;
+            params.old_configuration_id = collection.configuration_id;
             return resolve(params);
           }
         }
-        if (validateID) {
-          return reject(new Error('Configured DISCOVERY_COLLECTION_ID=' + validateID + ' not found.'));
-        }
-        // No collection_id added, but return params dict. Set the name to use to create a collection.
-        params.collection_name = DISCOVERY_COLLECTION_NAME;
-        return resolve(params);
+
+        return reject(new Error('Configured DISCOVERY_COLLECTION_ID=' + validateID + ' not found.'));
       }
     });
   });
@@ -287,34 +294,33 @@ WatsonDiscoverySetup.prototype.createDiscoveryEnvironment = function(params) {
 };
 
 /**
- * Create a Discovery collection if we did not find one.
+ * Update the Discovery collection if it is using the wrong configuration.
  * If params include a collection_id, then we already have one.
  * When we create one, we have to create it with our known name
  * so that we can find it later.
  * @param {Object} params - All the params needed to use Discovery.
  * @return {Promise}
  */
-WatsonDiscoverySetup.prototype.createDiscoveryCollection = function(params) {
-  if (params.collection_id) {
+WatsonDiscoverySetup.prototype.updateDiscoveryCollection = function(params) {
+  if (params.old_configuration_id === params.configuration_id) {
     return Promise.resolve(params);
   }
+
   return new Promise((resolve, reject) => {
-    // No existing environment found, so create it.
-    console.log('Creating discovery collection...');
-    const createCollectionParams = {
+    console.log('Updating discovery collection...');
+    const updateCollectionParams = {
       name: params.collection_name,
       description: 'Discovery collection created by watson-discovery-food-reviews.',
-      language_code: 'en_us'
+      configuration_id: params.configuration_id
     };
-    Object.assign(createCollectionParams, params);
+    Object.assign(updateCollectionParams, params);
 
-    this.discoveryClient.createCollection(createCollectionParams, (err, data) => {
+    this.discoveryClient.updateCollection(updateCollectionParams, (err, data) => {
       if (err) {
-        console.error('Failed to create Discovery collection.');
+        console.error('Failed to update Discovery collection.');
         return reject(err);
       } else {
-        console.log('Created Discovery collection: ', data);
-        params.collection_id = data.collection_id;
+        console.log('Updated Discovery collection: ', data);
         resolve(params);
       }
     });
@@ -410,7 +416,7 @@ WatsonDiscoverySetup.prototype.setupDiscovery = function(setupParams, callback) 
     .then(params => this.findDiscoveryConfig(params))
     .then(params => this.getDefaultDiscoveryConfig(params))
     .then(params => this.createDiscoveryConfig(params))
-    .then(params => this.createDiscoveryCollection(params))
+    .then(params => this.updateDiscoveryCollection(params))
     .then(params => callback(null, params))
     .catch(callback);
 };

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,8 @@
 ---
 applications:
 - path: .
-  name: watson-discovery-food-reviews
+  name: watson-discovery-food-reviews-demo
   buildpack: sdk-for-nodejs
-  memory: 1024M
+  memory: 2048M
+  random-route: false
   instances: 1

--- a/server/index.js
+++ b/server/index.js
@@ -36,6 +36,8 @@ const utils = require('../lib/utils');
 
 var environment_id;
 var collection_id;
+const model_id = process.env.WKS_MODEL_ID;
+
 const DEFAULT_NAME = 'food-reviews';
 var discoveryDocs = [];
 const fs = require('fs');
@@ -60,7 +62,8 @@ discovery.query = Promise.promisify(discovery.query);
 const discoverySetup = new WatsonDiscoverySetup(discovery);
 const discoverySetupParams = {
   default_name: DEFAULT_NAME,
-  config_name: 'foodie-keyword-extraction'   // instead of 'Default Configuration'
+  config_name: 'food-review-config',   // instead of 'Default Configuration',
+  model_id: model_id
 };
 
 const WatsonDiscoServer = new Promise((resolve) => {
@@ -80,6 +83,7 @@ const WatsonDiscoServer = new Promise((resolve) => {
       collection_id = collectionParams.collection_id;
       console.log('environment_id: ' + environment_id);
       console.log('collection_id: ' + collection_id);
+      console.log('model_id: ' + model_id);
       queryBuilder.setEnvironmentId(environment_id);
       queryBuilder.setCollectionId(collection_id);
       queryCustomBuilder.setEnvironmentId(environment_id);


### PR DESCRIPTION
- eliminated need for user to create disco collection configuration. 
- requires user add "wks_model_id" in .env file
- disco setup requires collection exist and then creates/uses correct configuration and attaches it
- modified README to reflect changes. Moved manual steps for setting up configuration to the bottom for reference.
- this change allows us to set up configuration with additional "mentions" enrichment that is not available thru the normal disco tooling UI. This will result in better highlighting of key words in app UI.